### PR TITLE
add hashbang for script

### DIFF
--- a/inject-env.js
+++ b/inject-env.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 
 const {


### PR DESCRIPTION
add hashbang  to fix `node_modules/.bin/china-bin-env: line 1: use strict: command not found`